### PR TITLE
Изменены файлы device.v и library/sdcrtt.v

### DIFF
--- a/design_09/device.v
+++ b/design_09/device.v
@@ -11,10 +11,10 @@ module device(D, s, r, clk, Q);
     nand2   u1(s, r, tmp1),
             u2(s, tmp1, tmp2[0]),
             u3(r, tmp1, tmp2[1]);
-    sdcrtt  u4(.clk(nc), .d(D),    .s(tmp3[0]), .r(tmp3[1]), .q(Q[0]), nq()),
-            u5(.clk(nc), .d(Q[0]), .s(tmp3[0]), .r(tmp3[1]), .q(Q[1]), nq()),
-            u6(.clk(nc), .d(Q[1]), .s(tmp3[0]), .r(tmp3[1]), .q(Q[2]), nq()),
-            u7(.clk(nc), .d(Q[2]), .s(tmp3[0]), .r(tmp3[1]), .q(Q[3]), nq());
+    sdcrtt  u4(.clk(nc), .d(D),    .s(tmp3[0]), .r(tmp3[1]), .q(Q[0]), .nq()),
+            u5(.clk(nc), .d(Q[0]), .s(tmp3[0]), .r(tmp3[1]), .q(Q[1]), .nq()),
+            u6(.clk(nc), .d(Q[1]), .s(tmp3[0]), .r(tmp3[1]), .q(Q[2]), .nq()),
+            u7(.clk(nc), .d(Q[2]), .s(tmp3[0]), .r(tmp3[1]), .q(Q[3]), .nq());
     not     u8(nc, clk),
             u9(tmp3[0], tmp2[0]),
             uA(tmp3[1], tmp2[1]);

--- a/design_09/library/sdcrtt.v
+++ b/design_09/library/sdcrtt.v
@@ -3,11 +3,11 @@ module sdcrtt(clk, d, s, r, q, nq);
     output reg  q, nq;
 
     always@(posedge clk, posedge r, posedge s)
-        if(s == 1'b1 && r == 1'b0) begin
+        if(s == 0 && r == 1) begin
             q <= 1'b0;
             nq <= 1'b1;
         end
-        else if(s == 1'b0 && r == 1'b1) begin
+        else if(s == 1 && r == 0) begin
             q <= 1'b1;
             nq <= 1'b0;
         end


### PR DESCRIPTION
В файле  device.v была синтаксическая ошибка -  не доставало точек в объявлении пинов в экземпляре модуля sdcrtt.
В файле library/sdcrtt.v была логическая ошибка - неправильно работали сброс и установка.